### PR TITLE
Fix type errors in high-priority modules (Issue #7 - Phase 2, Part 3)

### DIFF
--- a/irb_segmentation/config.py
+++ b/irb_segmentation/config.py
@@ -5,7 +5,7 @@ Unified configuration class for the entire segmentation workflow.
 """
 
 from dataclasses import dataclass, field, asdict
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, cast
 from pathlib import Path
 import json
 import yaml
@@ -301,7 +301,7 @@ class SegmentationConfig:
             SegmentationConfig instance
         """
         from interfaces.excel_to_config import ConfigFromExcel
-        return ConfigFromExcel.import_config(filepath)
+        return cast('SegmentationConfig', ConfigFromExcel.import_config(filepath))
 
     def to_csv(self, filepath: str) -> None:
         """
@@ -328,7 +328,7 @@ class SegmentationConfig:
             SegmentationConfig instance
         """
         from interfaces.config_csv import ConfigCSV
-        return ConfigCSV.from_csv(filepath)
+        return cast('SegmentationConfig', ConfigCSV.from_csv(filepath))
 
     def summary(self) -> str:
         """

--- a/irb_segmentation/validators/input_validator.py
+++ b/irb_segmentation/validators/input_validator.py
@@ -141,7 +141,7 @@ def validate_array(
 
     # Check for NaN values
     if not allow_nan and np.any(np.isnan(X)):
-        n_nan = np.sum(np.isnan(X))
+        n_nan: int = int(np.sum(np.isnan(X)))
         pct_nan = 100 * n_nan / X.size
         raise ValidationError(
             f"{name} contains NaN values",
@@ -153,7 +153,7 @@ def validate_array(
 
     # Check for infinity values
     if not allow_inf and np.any(np.isinf(X)):
-        n_inf = np.sum(np.isinf(X))
+        n_inf: int = int(np.sum(np.isinf(X)))
         pct_inf = 100 * n_inf / X.size
         raise ValidationError(
             f"{name} contains infinity values",
@@ -229,7 +229,7 @@ def validate_binary_target(
 
     # Check for NaN
     if np.any(np.isnan(y)):
-        n_nan = np.sum(np.isnan(y))
+        n_nan: int = int(np.sum(np.isnan(y)))
         raise ValidationError(
             f"{name} contains NaN values",
             field=name,

--- a/irb_segmentation/validators/residual_analysis.py
+++ b/irb_segmentation/validators/residual_analysis.py
@@ -217,7 +217,7 @@ def analyze_residuals(
     # Durbin-Watson statistic
     # DW = sum((e_t - e_{t-1})^2) / sum(e_t^2)
     diff_residuals = np.diff(residuals)
-    dw = np.sum(diff_residuals ** 2) / np.sum(residuals ** 2)
+    dw: float = float(np.sum(diff_residuals ** 2) / np.sum(residuals ** 2))
 
     logger.info(
         f"Residual analysis: mean={mean_res:.6f}, std={std_res:.4f}, "
@@ -225,8 +225,8 @@ def analyze_residuals(
     )
 
     results = ResidualAnalysisResults(
-        mean_residual=mean_res,
-        std_residual=std_res,
+        mean_residual=float(mean_res),
+        std_residual=float(std_res),
         skewness=skew,
         kurtosis=kurt,
         normality_test_statistic=jb_stat,
@@ -300,7 +300,7 @@ def breusch_pagan_test(
     n, p = X.shape
 
     # Squared residuals
-    u2 = residuals ** 2
+    u2: np.ndarray = residuals ** 2
 
     # Add intercept to X if not present
     if not np.allclose(X[:, 0], 1.0):
@@ -323,7 +323,7 @@ def breusch_pagan_test(
 
     # Explained sum of squares
     u2_mean = np.mean(u2)
-    ess = np.sum((u2_fitted - u2_mean) ** 2)
+    ess: float = float(np.sum((u2_fitted - u2_mean) ** 2))
 
     # Test statistic: ESS / 2σ⁴ ~ χ²(p) under H₀
     # Using simplified version: ESS / 2 (assuming σ² = 1 after standardization)
@@ -346,7 +346,7 @@ def breusch_pagan_test(
 
     results = HeteroscedasticityTestResults(
         test_name="Breusch-Pagan",
-        test_statistic=test_stat,
+        test_statistic=float(test_stat),
         pvalue=pval,
         is_homoscedastic=is_homoscedastic,
         degrees_of_freedom=df
@@ -434,7 +434,7 @@ def white_test(
     X_augmented = np.column_stack(X_augmented)
 
     # Squared residuals
-    u2 = residuals ** 2
+    u2: np.ndarray = residuals ** 2
 
     # Regress u² on X_augmented
     try:
@@ -450,8 +450,8 @@ def white_test(
 
     # R² from auxiliary regression
     u2_mean = np.mean(u2)
-    ss_total = np.sum((u2 - u2_mean) ** 2)
-    ss_residual = np.sum((u2 - u2_fitted) ** 2)
+    ss_total: float = float(np.sum((u2 - u2_mean) ** 2))
+    ss_residual: float = float(np.sum((u2 - u2_fitted) ** 2))
     r_squared = 1 - (ss_residual / ss_total) if ss_total > 0 else 0
 
     # Test statistic: n * R² ~ χ²(df) under H₀
@@ -513,7 +513,7 @@ def run_all_residual_diagnostics(
     """
     logger.info("Running comprehensive residual diagnostics")
 
-    results = {}
+    results: Dict[str, Union[ResidualAnalysisResults, HeteroscedasticityTestResults]] = {}
 
     # Residual analysis (always performed)
     results['residual_analysis'] = analyze_residuals(y_true, y_pred, alpha)


### PR DESCRIPTION
Summary of Changes:
- Fixed config.py: Added cast() for external function returns (2 errors fixed)
- Fixed input_validator.py: Added type annotations for local variables (3 errors fixed)
- Fixed residual_analysis.py: Added type annotations and float() conversions (11 errors fixed)

Specific Fixes:
- config.py: Used cast() for from_excel() and from_csv() return values
- input_validator.py: Typed n_nan and n_inf variables
- residual_analysis.py:
  - Typed dw, u2, ess, ss_total, ss_residual variables
  - Added float() conversions for mean_residual, std_residual, test_statistic
  - Typed results dict with proper Union type

Results:
- config.py: 2 → 0 mypy errors (100% reduction)
- input_validator.py: 3 → 0 mypy errors (100% reduction)
- residual_analysis.py: 11 → 0 mypy errors (100% reduction)
- Overall project: 84 → 68 errors (19% reduction)
- All 350 tests still passing
- No breaking changes

This completes Phase 2 Part 3 of Issue #7, bringing type safety to config and validator modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)